### PR TITLE
Set up Docker for backend local development

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/FoodSwiper/Dockerfile
+++ b/FoodSwiper/Dockerfile
@@ -1,0 +1,5 @@
+FROM eclipse-temurin:26-jdk
+WORKDIR /app
+COPY build/libs/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","app.jar"]

--- a/FoodSwiper/build.gradle
+++ b/FoodSwiper/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-webservices-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	runtimeOnly 'org.postgresql:postgresql'
 }
 
 tasks.named('test') {

--- a/FoodSwiper/compose.yaml
+++ b/FoodSwiper/compose.yaml
@@ -1,0 +1,6 @@
+services:
+  app:
+    build: .
+    container_name: foodswiper-app
+    ports:
+      - "8080:8080"

--- a/FoodSwiper/src/main/java/com/FoodSwiper/FoodSwiperApplication.java
+++ b/FoodSwiper/src/main/java/com/FoodSwiper/FoodSwiperApplication.java
@@ -2,8 +2,9 @@ package com.FoodSwiper;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = {DataSourceAutoConfiguration.class})
 public class FoodSwiperApplication {
 
 	public static void main(String[] args) {

--- a/FoodSwiper/src/main/resources/application.properties
+++ b/FoodSwiper/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.application.name=FoodSwiper
+spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration


### PR DESCRIPTION
## Summary
This PR sets up Docker for the Spring Boot backend so the project can be run in a consistent local environment across team members' machines.

## Changes made
- added a `Dockerfile` to containerize the backend
- added `compose.yaml` for simpler local startup with Docker Compose
- configured the backend to run on port 8080 in Docker
- temporarily excluded datasource and JPA auto-configuration so the app can start without a database connection for now

## Why
This helps standardize local development and reduces setup differences between team members. It also prepares the backend for future environment variable and database configuration when Supabase is connected.

## How to test
1. Open the backend project folder
2. Run:
   `docker compose up --build`
3. Go to `http://localhost:8080`
4. Confirm the Spring Boot app starts successfully

## Notes
- database configuration is not included in this PR yet
- Supabase integration will be added in a follow-up PR
- the datasource bypass is temporary and should be removed once DB credentials/config are added