### PR TITLE
Added OAuth2 login support with GitHub and Google using Spring Security.

### DIFF
--- a/FoodSwiper/.gitignore
+++ b/FoodSwiper/.gitignore
@@ -35,3 +35,8 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Env / secrets ###
+.env
+.env.*
+!.env.example

--- a/FoodSwiper/build.gradle
+++ b/FoodSwiper/build.gradle
@@ -23,6 +23,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webservices'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-hateoas'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	runtimeOnly 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-webclient-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'

--- a/FoodSwiper/compose.yaml
+++ b/FoodSwiper/compose.yaml
@@ -4,3 +4,8 @@ services:
     container_name: foodswiper-app
     ports:
       - "8080:8080"
+    environment:
+      GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID}
+      GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET}
+      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
+      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}

--- a/FoodSwiper/env.example
+++ b/FoodSwiper/env.example
@@ -1,0 +1,4 @@
+GOOGLE_CLIENT_ID=replace-me
+GOOGLE_CLIENT_SECRET=replace-me
+GITHUB_CLIENT_ID=replace-me
+GITHUB_CLIENT_SECRET=replace-me

--- a/FoodSwiper/src/main/java/com/FoodSwiper/SecurityConfig.java
+++ b/FoodSwiper/src/main/java/com/FoodSwiper/SecurityConfig.java
@@ -1,0 +1,24 @@
+package com.FoodSwiper;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/", "/error").permitAll()
+                .requestMatchers("/restaurants/**", "/foods/**").authenticated()
+                .anyRequest().authenticated()
+            )
+            .oauth2Login(Customizer.withDefaults());
+
+        return http.build();
+    }
+}

--- a/FoodSwiper/src/main/java/com/FoodSwiper/UserProfileController.java
+++ b/FoodSwiper/src/main/java/com/FoodSwiper/UserProfileController.java
@@ -1,0 +1,16 @@
+package com.FoodSwiper;
+
+import java.util.Map;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class UserProfileController {
+
+    @GetMapping("/me")
+    public Map<String, Object> me(@AuthenticationPrincipal OAuth2User principal) {
+        return principal.getAttributes();
+    }
+}

--- a/FoodSwiper/src/main/resources/application.properties
+++ b/FoodSwiper/src/main/resources/application.properties
@@ -3,3 +3,11 @@ server.port=8080
 spring.datasource.url=jdbc:h2:mem:testdb
 spring.datasource.driver-class-name=org.h2.Driver
 spring.jpa.hibernate.ddl-auto=create-drop
+
+spring.security.oauth2.client.registration.google.client-id=${GOOGLE_CLIENT_ID}
+spring.security.oauth2.client.registration.google.client-secret=${GOOGLE_CLIENT_SECRET}
+spring.security.oauth2.client.registration.google.scope=openid,profile,email
+
+spring.security.oauth2.client.registration.github.client-id=${GITHUB_CLIENT_ID}
+spring.security.oauth2.client.registration.github.client-secret=${GITHUB_CLIENT_SECRET}
+spring.security.oauth2.client.registration.github.scope=read:user,user:email


### PR DESCRIPTION
## Summary
This PR adds OAuth2 authentication to the backend using Spring Security, with support for GitHub and Google login.

## What changed
- added `spring-boot-starter-security`
- added `spring-boot-starter-oauth2-client`
- configured OAuth2 client registrations for GitHub and Google
- added `SecurityConfig` to require authentication on protected routes
- added `/me` endpoint to verify authenticated OAuth user data
- added environment-variable based config for client IDs and secrets
- updated Docker setup so OAuth variables can be passed through containers
- updated `.gitignore` to avoid committing secret env files

## Why
This allows users to sign in with existing GitHub or Google accounts instead of requiring local authentication, and gives the project a more realistic production-style auth flow.

## Notes
- GitHub login is working and `/me` returns authenticated GitHub user data
- GitHub may return `email = null`, so provider ID is the more reliable unique identifier
- Google credentials may still depend on final client setup and team configuration

## Testing
- confirmed app starts with OAuth config
- confirmed GitHub login redirects correctly
- confirmed successful login returns authenticated user attributes at `/me`
- confirmed Docker Compose passes OAuth environment variables correctly

Closes issue #27 